### PR TITLE
[d3d8] Fix tests output not being displayed

### DIFF
--- a/d3d8/d3d8_triangle.cpp
+++ b/d3d8/d3d8_triangle.cpp
@@ -822,3 +822,7 @@ INT WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInstance,
         return msg.wParam;
     }
 }
+
+int main(int, char**) {
+    return WinMain(GetModuleHandle(NULL), NULL, GetCommandLineA(), SW_SHOWNORMAL);
+}

--- a/d3d8/meson.build
+++ b/d3d8/meson.build
@@ -3,5 +3,5 @@ args = {
   'install': true
 }
 
-executable('d3d8-triangle', files('d3d8_triangle.cpp'), gui_app: true, kwargs: args)
+executable('d3d8-triangle', files('d3d8_triangle.cpp'), kwargs: args)
 


### PR DESCRIPTION
Fix a small derp. While it is essentially a d3d8 triangle, the initial part of it (namely the d3d8 tests and stats) rely on outputting to a command prompt. Tested it with `gui_app: false` on both Windows and Linux and it does what it's supposed to, at least when using mingw. Not sure about MSVC, but it _should_ behave similarly.