### PR TITLE
Add a nice workflow

### DIFF
--- a/.github/actions/project_build/action.yml
+++ b/.github/actions/project_build/action.yml
@@ -1,0 +1,26 @@
+name: "Build with Meson and Ninja"
+description: "Checks out code, sets up Python, and builds using Meson and Ninja"
+inputs:
+  python-version:
+    description: "Python version to use"
+    required: true
+    default: "3.x"
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Meson and Ninja
+      run: pip install meson ninja
+      shell: bash
+
+    - name: Configure build with Meson
+      run: meson setup builddir
+      shell: bash
+
+    - name: Build with Ninja
+      run: ninja -C builddir
+      shell: bash

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -1,0 +1,21 @@
+name: Verify Pull Request
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Build project action
+        uses: ./.github/actions/project_build

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,116 @@
+name: Release Releases for dxvk-tests
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v[0-9]+.*
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build_artifacts:
+    runs-on: windows-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Build project action
+        uses: ./.github/actions/project_build
+
+      - name: Find all exe files in builddir
+        id: Finder
+        run: |
+          {
+            echo "exe_files<<EOF"
+            echo "$(find builddir/d3d9 builddir/d3d11 -name '*.exe' -type f)"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: |
+            ${{ steps.Finder.outputs.exe_files }}
+
+  do_release:
+    runs-on: ubuntu-latest
+    needs: build_artifacts
+    steps:
+      - name: Unpack build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: builddir
+
+      - name: Delete existing latest_build Pre-Release
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            for (const release of releases) {
+              if (release.prerelease && release.name.startsWith('Latest build of branch')) {
+                await github.rest.repos.deleteRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: release.id,
+                });
+              }
+            }
+            const { data: tags } = await github.rest.git.listMatchingRefs({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'tags/latest_build',
+            });
+            if (tags.length > 0)
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'tags/latest_build',
+              });
+
+      - name: Check Tag Format
+        id: check_tag
+        if: startsWith(github.ref, 'refs/tags/') # Ensure this runs for tags only
+        run: |
+          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+.*$ ]]; then
+            echo "tag_matches=true" >> $GITHUB_OUTPUT
+          else
+            echo "tag_matches=false" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
+      - name: Create latest build Pre-Release
+        if: steps.check_tag.outputs.tag_matches != 'true'
+        uses: ncipollo/release-action@v1
+        with:
+          prerelease: true
+          draft: false
+          allowUpdates: true
+          removeArtifacts: true
+          name: Latest build of branch ${{ github.ref_name }}
+          commit: ${{ github.ref }}
+          tag: latest_build
+          artifacts: |
+            builddir/**/*.exe
+
+      - name: Create Tagged Release
+        if: steps.check_tag.outputs.tag_matches == 'true'
+        uses: ncipollo/release-action@v1
+        with:
+          prerelease: false
+          removeArtifacts: true
+          name: Release ${{ github.ref_name }}
+          tag: ${{ github.ref_name }}
+          artifacts: |
+            builddir/**/*.exe

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
+# DXVK-TESTS
+
 This repository contains test applications that used to be part of [DXVK](https://github.com/doitsujin/dxvk). These are generally not useful for end users.
+
+## Building
+
+Prequisites:
+* [Meson](https://mesonbuild.com/)
+* [Ninja](https://ninja-build.org/)
+
+```cmd
+mkdir setup build
+ninja -C build
+```


### PR DESCRIPTION
This workflow does the following:
* On push on main a prerelease is created and continuously updated with the latest files.
* If a tag `v1.1.1` is pushed a normal release is created.
* Pull requests are checked for a passing build.

Please consider adding this because linux users wanting to test dxvk may not have a windows machine readily available.